### PR TITLE
Bypass routing

### DIFF
--- a/kmod/module/service.sh
+++ b/kmod/module/service.sh
@@ -115,20 +115,37 @@ fi
     heartbeat=0
 
     while true; do
-        if [ -f "$TRIGGER" ] || [ -z "$last_idx" ] || [ "$heartbeat" -ge 5 ]; then
+        if [ -f "$TRIGGER" ] || [ -z "$last_idx" ] || [ "$heartbeat" -ge 2 ]; then
             rm -f "$TRIGGER"
             heartbeat=0
             
             sleep 0.5
             
-            phys_iface=$(ip route show table all | grep "default via" | grep -vE "tun|wg|dummy|p2p" | head -n1 | awk '{print $5}')
+            phys_iface=""
             
+            # 1. Получаем ID активной интернет-сети (например, 103)
+            net_id=$(dumpsys connectivity | grep "Active default network:" | grep -oE "[0-9]+")
+            
+            if [ -n "$net_id" ]; then
+                # 2. Ищем строку с этим ID и вытаскиваем точное имя интерфейса (InterfaceName)
+                phys_iface=$(dumpsys connectivity | grep -E "network\{$net_id\}|NetID.*$net_id" | grep -oE "InterfaceName: [^ ]+" | head -n1 | awk -F': ' '{print $2}' | tr -d '},')
+            fi
+            
+            # 3. Железобетонная страховка: если dumpsys зависнет или не отдаст ID
+            if [ -z "$phys_iface" ]; then
+                phys_iface=$(ip route show table all | grep "default via" | grep -vE "tun|wg|dummy|p2p|ccmni2" | head -n1 | awk '{print $5}')
+            fi
+
+            # 4. === ТОТ САМЫЙ КУСОК, КОТОРЫЙ ВЫ ПОТЕРЯЛИ ===
+            # Если интерфейс найден, получаем его индекс и отправляем в ядро
             if [ -n "$phys_iface" ]; then
                 phys_ifindex=$(cat "/sys/class/net/$phys_iface/ifindex" 2>/dev/null)
                 
                 if [ -n "$phys_ifindex" ]; then
+                    # Пишем в ядро при любом обновлении
                     echo "$phys_ifindex" > /proc/vpnhide_phys_ifindex
-
+                    
+                    # Пишем в лог только при реальной смене
                     if [ "$phys_ifindex" != "$last_idx" ]; then
                         log -t vpnhide "routing: active physical interface changed to $phys_iface ($phys_ifindex)"
                         last_idx="$phys_ifindex"

--- a/kmod/module/service.sh
+++ b/kmod/module/service.sh
@@ -112,40 +112,34 @@ fi
     ) &
 
     last_idx=""
-    heartbeat=0
+    heartbeat_counter=0
+    HEARTBEAT_MAX=75 
 
     while true; do
-        if [ -f "$TRIGGER" ] || [ -z "$last_idx" ] || [ "$heartbeat" -ge 2 ]; then
+        if [ -f "$TRIGGER" ] || [ -z "$last_idx" ] || [ "$heartbeat_counter" -ge "$HEARTBEAT_MAX" ]; then
             rm -f "$TRIGGER"
-            heartbeat=0
-            
-            sleep 0.5
+            heartbeat_counter=0
+
+            sleep 0.3
             
             phys_iface=""
-            
-            # 1. Получаем ID активной интернет-сети (например, 103)
+
             net_id=$(dumpsys connectivity | grep "Active default network:" | grep -oE "[0-9]+")
             
             if [ -n "$net_id" ]; then
-                # 2. Ищем строку с этим ID и вытаскиваем точное имя интерфейса (InterfaceName)
                 phys_iface=$(dumpsys connectivity | grep -E "network\{$net_id\}|NetID.*$net_id" | grep -oE "InterfaceName: [^ ]+" | head -n1 | awk -F': ' '{print $2}' | tr -d '},')
             fi
-            
-            # 3. Железобетонная страховка: если dumpsys зависнет или не отдаст ID
+    
             if [ -z "$phys_iface" ]; then
                 phys_iface=$(ip route show table all | grep "default via" | grep -vE "tun|wg|dummy|p2p|ccmni2" | head -n1 | awk '{print $5}')
             fi
 
-            # 4. === ТОТ САМЫЙ КУСОК, КОТОРЫЙ ВЫ ПОТЕРЯЛИ ===
-            # Если интерфейс найден, получаем его индекс и отправляем в ядро
             if [ -n "$phys_iface" ]; then
                 phys_ifindex=$(cat "/sys/class/net/$phys_iface/ifindex" 2>/dev/null)
                 
                 if [ -n "$phys_ifindex" ]; then
-                    # Пишем в ядро при любом обновлении
                     echo "$phys_ifindex" > /proc/vpnhide_phys_ifindex
                     
-                    # Пишем в лог только при реальной смене
                     if [ "$phys_ifindex" != "$last_idx" ]; then
                         log -t vpnhide "routing: active physical interface changed to $phys_iface ($phys_ifindex)"
                         last_idx="$phys_ifindex"
@@ -153,9 +147,9 @@ fi
                 fi
             fi
         fi
-        
-        sleep 1
-        heartbeat=$((heartbeat + 1))
+
+        sleep 0.2 
+        heartbeat_counter=$((heartbeat_counter + 1))
     done
 ) &
 


### PR DESCRIPTION
1. Перенес логику поиска интерфейса в user space. При каждой смене интерфейса/истечению таймера обновляется id интерфейса в /proc/vpnhide_phys_ifindex. Ядро занимается только маршрутизацией
2. Убрал любые попытки определения приоритетного интерфейса из ядра